### PR TITLE
Bugfix/launchfile argument

### DIFF
--- a/launch/yolov5.launch
+++ b/launch/yolov5.launch
@@ -28,7 +28,7 @@
 
 
     <node pkg="yolov5_ros" name="detect" type="detect.py" output="screen">
-        <param name="weights"               value="yolov5m.pt"/>
+        <param name="weights"               value="$(arg weights)"/>
         <param name="data"                  value="$(arg data)"/>
         <param name="confidence_threshold"  value="$(arg confidence_threshold)"/>
         <param name="iou_threshold"         value="$(arg iou_threshold)" />

--- a/launch/yolov5_d435.launch
+++ b/launch/yolov5_d435.launch
@@ -28,7 +28,7 @@
 
 
     <node pkg="yolov5_ros" name="detect" type="detect.py" output="screen">
-        <param name="weights"               value="yolov5m.pt"/>
+        <param name="weights"               value="$(arg weights)"/>
         <param name="data"                  value="$(arg data)"/>
         <param name="confidence_threshold"  value="$(arg confidence_threshold)"/>
         <param name="iou_threshold"         value="$(arg iou_threshold)" />


### PR DESCRIPTION
In bot launch files, the argument "weights" was defined at the top but not passed to the node when it was started, instead the argument was hardcoded into the file.
This should fix it.